### PR TITLE
case of missing content-type header

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -3,7 +3,7 @@ const util = {};
 util.isJsonResponse = function(res) {
   if (res.headers) {
     const headers = res.headers;
-    if (headers.get('content-type') == undefined) return false; // no content-type header    
+    if (headers.get('content-type') === undefined) return false; // no content-type header    
     const h = headers.get('content-type').toLowerCase();
     if (h.toLowerCase().indexOf('application/json') > -1) {
       return true;

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,7 @@ const util = {};
 util.isJsonResponse = function(res) {
   if (res.headers) {
     const headers = res.headers;
+    if (headers.get('content-type') == undefined) return false; // no content-type header    
     const h = headers.get('content-type').toLowerCase();
     if (h.toLowerCase().indexOf('application/json') > -1) {
       return true;


### PR DESCRIPTION
`isJsonResponse` in util.js breaks when there is no content-type header present.

I found this error when fixing some bugs in `node-red-contrib-salesforce` package. Looks like recent SF orgs not always send back content type!